### PR TITLE
Fix key name in exports field

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -22,7 +22,7 @@
   "exports": {
     ".": {
       "import": "./dist/impulse.es.mjs",
-      "type": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
I installed `@impulse.dev/runtime@latest` and tried it and got an error message that the type definition could not be found.
It looked to me like there was an mistake in the key name in the exports field.

<img width="507" alt="" src="https://github.com/impulse-oss/impulse/assets/1129027/85ca6b2d-0f4c-429c-a218-4107e79d7139">
